### PR TITLE
Return the `null` string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,16 @@
+sudo: false
 language: node_js
 node_js:
+  - "4"
+  - "iojs"
   - "0.12"
-  - "0.11"
   - "0.10"
-  - "0.9"
-  - "0.8"
-  - "iojs-v1.1"
-  - "iojs-v1.0"
-before_install:
-  - "npm install -g npm@1.4.x"
 script:
   - "npm run test-travis"
 after_script:
-  - "npm install coveralls@2.11.x && cat coverage/lcov.info | coveralls"
+  - "npm install coveralls@2 && cat coverage/lcov.info | coveralls"
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: "0.11"
-    - node_js: "0.9"
-    - node_js: "iojs-v1.1"
-    - node_js: "iojs-v1.0"
 notifications:
   irc:
     channels:

--- a/index.js
+++ b/index.js
@@ -10,27 +10,13 @@ var parse = require('url-parse');
  * @api public
  */
 function origin(url) {
-  if ('string' === typeof url) {
-    //
-    // In order to correctly parse an URL it needs to be prefixed with
-    // a protocol or the parsers will all assume that the information we've
-    // given is a pathname instead of an URL. So we need to do a sanity check
-    // before parsing.
-    //
-    if (!/^(http|ws|file|blob)s?:/i.test(url)) url = 'http://'+ url;
-    url = parse(url.toLowerCase());
-  }
+  if ('string' === typeof url) url = parse(url);
 
   //
   // 6.2.  ASCII Serialization of an Origin
   // http://tools.ietf.org/html/rfc6454#section-6.2
   //
-  // @TODO If we cannot generate a proper origin from the URL because
-  // origin/host/port information is missing we should return the string `null`
-  //
-
-  var protocol = url.protocol
-    , port = url.port && +url.port;
+  if (!url.protocol || !url.hostname) return 'null';
 
   //
   // 4. Origin of a URI
@@ -39,7 +25,7 @@ function origin(url) {
   // States that url.scheme, host should be converted to lower case. This also
   // makes it easier to match origins as everything is just lower case.
   //
-  return (url.protocol +'//'+ url.hostname + (!port ? '' : ':'+ port)).toLowerCase();
+  return (url.protocol +'//'+ url.host).toLowerCase();
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
-    "test": "mocha test.js",
+    "test-travis": "istanbul cover _mocha --report lcovonly -- test.js",
+    "coverage": "istanbul cover _mocha -- test.js",
     "watch": "mocha --watch test.js",
-    "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
-    "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js"
+    "test": "mocha test.js"
   },
   "repository": {
     "type": "git",
@@ -25,9 +25,9 @@
     "url-parse": "1.0.x"
   },
   "devDependencies": {
-    "assume": "1.1.x",
-    "istanbul": "0.3.x",
-    "mocha": "2.1.x",
-    "pre-commit": "1.0.x"
+    "assume": "1.3.x",
+    "istanbul": "0.4.x",
+    "mocha": "2.3.x",
+    "pre-commit": "1.1.x"
   }
 }

--- a/test.js
+++ b/test.js
@@ -33,10 +33,16 @@ describe('original', function () {
     assume(o).equals('https://www.example.com:8080');
   });
 
-  it('also accepts missing protocols', function () {
+  it('returns "null" if the protocol is not specified', function () {
     var o = origin('www.example.com');
 
-    assume(o).equals('http://www.example.com');
+    assume(o).equals('null');
+  });
+
+  it('returns "null" if the hostname is not specified', function () {
+    var o = origin('http://');
+
+    assume(o).equals('null');
   });
 
   it('removes default ports for http', function () {


### PR DESCRIPTION
This is a breaking change to follow the [RFC 6454](http://tools.ietf.org/html/rfc6454#section-6.1) specifications.

If we can't build a scheme/host/port triple we should return the `null` string.
