### PR TITLE
Update url-parse to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Arnout Kazemier",
   "license": "MIT",
   "dependencies": {
-    "url-parse": "^1.4.3"
+    "url-parse": "^1.5.1"
   },
   "devDependencies": {
     "assume": "~2.1.0",


### PR DESCRIPTION
url-parse before 1.5.0 mishandles certain uses of backslash such as http:\/ and interprets the URI as a relative path.

for more details: https://nvd.nist.gov/vuln/detail/CVE-2021-27515