### PR TITLE
Update url-parse to avoid open redirect due to improper escaping of slash characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Arnout Kazemier",
   "license": "MIT",
   "dependencies": {
-    "url-parse": "^1.5.1"
+    "url-parse": "^1.5.2"
   },
   "devDependencies": {
     "assume": "~2.2.0",


### PR DESCRIPTION
Related https://app.snyk.io/vuln/SNYK-JS-URLPARSE-1533425 and https://github.com/unshiftio/url-parse/pull/208