### PR TITLE
[pkg] Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   "author": "Arnout Kazemier",
   "license": "MIT",
   "dependencies": {
-    "url-parse": "^1.5.1"
+    "url-parse": "^1.5.7"
   },
   "devDependencies": {
     "assume": "~2.3.0",
-    "c8": "~7.10.0",
-    "mocha": "~9.1.3",
-    "pre-commit": "~1.2.0"
+    "c8": "~7.11.0",
+    "mocha": "~9.1.4",
+    "pre-commit": "~1.2.2"
   }
 }


### PR DESCRIPTION
PR to mainly upgrade `url-parse` to something equal or after `1.5.6`, but includes other dependency updates.

The motivation to upgrade `url-parse` is to address a vulnerability issue recently identified with `url-parse` versions older than `1.5.6`. Ran tests after the upgrade and they  all pass.


Vulnerability details: https://security.snyk.io/vuln/SNYK-JS-URLPARSE-2401205

![image](https://user-images.githubusercontent.com/8948739/154394631-ebe689e6-838b-4264-ad95-6e266407e0f3.png)

