### PR TITLE
Drop url-parse module and switch to standard URL module

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,27 +10,16 @@
 function origin(url) {
   if ('string' === typeof url) {
     try {
-      return new URL(url).origin;
+      url = new URL(url);
     } catch (er) {
       return 'null';
     }
-  } else {
-    return url.origin;
   }
 
-  //
-  // 6.2.  ASCII Serialization of an Origin
-  // http://tools.ietf.org/html/rfc6454#section-6.2
-  //
-  if (!url.protocol || !url.hostname) return 'null';
+  if (url.protocol !== 'file:') {
+    return url.origin
+  }
 
-  //
-  // 4. Origin of a URI
-  // http://tools.ietf.org/html/rfc6454#section-4
-  //
-  // States that url.scheme, host should be converted to lower case. This also
-  // makes it easier to match origins as everything is just lower case.
-  //
   return (url.protocol +'//'+ url.host).toLowerCase();
 }
 

--- a/index.js
+++ b/index.js
@@ -10,17 +10,11 @@
 function origin(url) {
   if ('string' === typeof url) {
     try {
-      url = new URL(url);
+      return new URL(url).origin;
     } catch (er) {
       return 'null';
     }
   }
-
-  if (url.protocol !== 'file:') {
-    return url.origin
-  }
-
-  return (url.protocol +'//'+ url.host).toLowerCase();
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var parse = require('url-parse');
-
 /**
  * Transform an URL to a valid origin value.
  *
@@ -10,7 +8,13 @@ var parse = require('url-parse');
  * @api public
  */
 function origin(url) {
-  if ('string' === typeof url) url = parse(url);
+  if ('string' === typeof url) {
+    try {
+      url = new URL(url);
+    } catch (er) {
+      return 'null';
+    }
+  }
 
   //
   // 6.2.  ASCII Serialization of an Origin

--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ function origin(url) {
     } catch (er) {
       return 'null';
     }
+  } else {
+    return url.origin;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ function origin(url) {
     } catch (er) {
       return 'null';
     }
+  } else {
+    return url.origin;
   }
 
   //

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
 function origin(url) {
   if ('string' === typeof url) {
     try {
-      url = new URL(url);
+      return new URL(url).origin;
     } catch (er) {
       return 'null';
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "author": "Arnout Kazemier",
   "license": "MIT",
   "dependencies": {
-    "url-parse": "^1.5.1"
   },
   "devDependencies": {
     "assume": "~2.3.0",

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ describe('original', function () {
   });
 
   it('also accepts objects instead of strings', function () {
-    var o = origin(new URL('http://google.com:80/pathname'));
+    var o = origin(new URL('http://google.com:80/pathname').origin);
     assume(o).equals('http://google.com');
   });
 

--- a/test.js
+++ b/test.js
@@ -44,7 +44,7 @@ describe('original', function () {
     assume(o).equals('null');
   });
 
-  it('returns "null" if the protocol is not file', function () {
+  it('returns "null" if the protocol is file:', function () {
     var o = origin('file://google.com/pathname');
     assume(o).equals('null');
   })

--- a/test.js
+++ b/test.js
@@ -1,8 +1,7 @@
 describe('original', function () {
   'use strict';
 
-  var parse = require('url-parse')
-    , assume = require('assume')
+  var assume = require('assume')
     , origin = require('./')
     , same = origin.same;
 
@@ -11,7 +10,7 @@ describe('original', function () {
   });
 
   it('also accepts objects instead of strings', function () {
-    var o = origin(parse('http://google.com:80/pathname'));
+    var o = origin(new URL('http://google.com:80/pathname').origin);
     assume(o).equals('http://google.com');
   });
 

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ describe('original', function () {
   });
 
   it('also accepts objects instead of strings', function () {
-    var o = origin(new URL('http://google.com:80/pathname').origin);
+    var o = origin(new URL('http://google.com:80/pathname'));
     assume(o).equals('http://google.com');
   });
 

--- a/test.js
+++ b/test.js
@@ -44,6 +44,11 @@ describe('original', function () {
     assume(o).equals('null');
   });
 
+  it('returns "null" if the protocol is not file', function () {
+    var o = origin('file://google.com/pathname');
+    assume(o).equals('null');
+  })
+
   it('removes default ports for http', function () {
     var o = origin('http://google.com:80/pathname');
     assume(o).equals('http://google.com');
@@ -62,9 +67,6 @@ describe('original', function () {
 
     o = origin('https://google.com:80/pathname');
     assume(o).equals('https://google.com:80');
-
-    o = origin('file://google.com/pathname');
-    assume(o).equals('file://google.com');
   });
 
   it('removes default ports for ws', function () {


### PR DESCRIPTION
This PR drops url-parse module from dependencies and uses the standard [URL module](https://developer.mozilla.org/en-US/docs/Web/API/URL/origin). Less dependencies - less issues 😄 